### PR TITLE
Remove -n option on read command

### DIFF
--- a/mecca
+++ b/mecca
@@ -5,7 +5,7 @@ echo "Ctrl+C to quit"
 echo "1 - New song"
 echo "2 - Load song"
 echo -n "> "
-read -n1 launch
+read launch
 echo ""
 if [ "$launch" = "1" ]; then
 	echo "Name your song:"
@@ -29,6 +29,7 @@ elif [ "$launch" = "2" ]; then
 	read song
 	echo ""
 else
+	echo "Please enter the number 1 or 2."
 	exit 1
 fi
 


### PR DESCRIPTION
When using the bash program for the first few times, a user might instinctively press Enter right after entering the number 1 for the 'New Song' option and inadvertently give an empty string for the song name. This commit removes the -n option on the read command so that the program will wait for the newline. If the user enters anything other than 1 or 2, a message is printed and the program terminates as before.